### PR TITLE
PageRank: Cast node to text in insert statement to match table data types

### DIFF
--- a/src/ports/greenplum/modules/pagerank/pagerank.sql_in
+++ b/src/ports/greenplum/modules/pagerank/pagerank.sql_in
@@ -275,11 +275,11 @@ $$
         sql = 'create table '|| pagerank_temp_node_tab ||' (node text) distributed randomly';
         execute(sql);
 
-        sql = 'insert into '|| pagerank_temp_node_tab ||' select distinct ' || source_node || 
+        sql = 'insert into '|| pagerank_temp_node_tab ||' select distinct ' || source_node || '::text' ||
             ' from ' || input_tab;
         execute(sql);
 
-        sql = 'insert into '|| pagerank_temp_node_tab ||' select distinct ' || dest_node || 
+        sql = 'insert into '|| pagerank_temp_node_tab ||' select distinct ' || dest_node || '::text' ||
             ' from ' || input_tab || ' where ' || dest_node || 
             ' not in (select distinct ' || source_node || '
             from ' || input_tab || ')' ;
@@ -474,13 +474,13 @@ $$
         execute(sql);
 
         sql = 'insert into '|| pagerank_temp_node_tab ||' 
-            select ' || source_node || ',' || graph_id || '::text 
+            select ' || source_node || '::text, ' || graph_id || '::text
             from ' || input_tab || ' 
             group by ' || source_node || ',' || graph_id;        
         execute(sql);
 
         sql = 'insert into '|| pagerank_temp_node_tab ||' 
-            select ' || dest_node || ',' || graph_id || '::text 
+            select ' || dest_node || '::text, ' || graph_id || '::text
             from ' || input_tab || ' 
             where ' || dest_node || '::text||' || graph_id || '::text
             not in (


### PR DESCRIPTION
Fixes error that occurs when one or both of the input node columns is of type other than text.

Error received before this fix:

psql:pagerank_script.sql:18: ERROR:  column "node" is of type text but expression is of type inet
HINT:  You will need to rewrite or cast the expression.
CONTEXT:  SQL statement "insert into __pagerank_temp_nodesyhwtkplys
            select ipv4_src_ip,hour_index::text
            from myschema.input_table
            group by ipv4_src_ip,hour_index"
PL/pgSQL function "pagerank" line 31 at execute statement
